### PR TITLE
Fix persistence restoration

### DIFF
--- a/src/domain/SearchEngine.js
+++ b/src/domain/SearchEngine.js
@@ -77,6 +77,9 @@ export default class SearchEngine {
         const state = this.persistence.loadSnapshotSync();
         if (state) {
             this.documents = new Map(state.documents);
+            // Ensure query engine uses the restored documents map
+            this.queryEngine.documents = this.documents;
+
             this.invertedIndex.index = new Map(
                 state.invertedIndex.map(([term, posting]) => [term, new Map(posting)])
             );
@@ -84,6 +87,11 @@ export default class SearchEngine {
             this.totalDocs = state.totalDocs;
             this.avgDocLength = state.avgDocLength;
             console.log(`Restored snapshot with ${this.totalDocs} documents`);
+
+            // Rebuild facet index from restored documents
+            for (const doc of this.documents.values()) {
+                this.facetEngine.add(doc);
+            }
 
             // Validate document consistency
             const docIds = new Set(this.documents.keys());

--- a/tests/persistence.test.js
+++ b/tests/persistence.test.js
@@ -1,0 +1,73 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { unlink } from 'node:fs/promises';
+
+import SearchEngine from '../src/domain/SearchEngine.js';
+import Tokenizer from '../src/domain/Tokenizer.js';
+import InvertedIndex from '../src/domain/InvertedIndex.js';
+import RankingPipeline from '../src/domain/RankingPipeline.js';
+import MappingsManager from '../src/domain/MappingsManager.js';
+import SnapshotPersistence from '../src/infrastructure/SnapshotPersistence.js';
+import SynonymEngine from '../src/domain/SynonymEngine.js';
+import BM25Scorer from '../src/domain/BM25Scorer.js';
+
+class MockStopwordsManager {
+    constructor() {
+        this.stopwords = new Set(['the', 'a', 'an', 'and', 'or', 'but', 'in', 'on', 'at', 'to', 'for', 'of', 'with', 'by']);
+    }
+    getAll() { return Array.from(this.stopwords); }
+    isStopword(word) { return this.stopwords.has(word.toLowerCase()); }
+    autoDetect() { return null; }
+}
+
+test('restores documents from snapshot without modification', async () => {
+    const snapshotPath = './persistence-test-snapshot.json';
+    await unlink(snapshotPath).catch(() => { });
+
+    const stopwordsManager = new MockStopwordsManager();
+    const mappingsManager = new MappingsManager();
+    mappingsManager.mappings.set('name', { type: 'text' });
+    const persistence = new SnapshotPersistence(snapshotPath);
+
+    const scorerFactory = (totalDocs, avgDocLength, docLengths, index) =>
+        new BM25Scorer(totalDocs, avgDocLength, docLengths, index);
+
+    let engine = new SearchEngine({
+        tokenizer: new Tokenizer(stopwordsManager),
+        scorerFactory,
+        invertedIndex: new InvertedIndex(),
+        rankingPipeline: new RankingPipeline(),
+        stopwordsManager,
+        synonymEngine: new SynonymEngine(),
+        mappingsManager,
+        persistence,
+        facetFields: ['status'],
+    });
+
+    const doc = { id: 'doc1', name: 'persistent doc', status: 'A' };
+    engine.add(doc);
+    engine.flush();
+    engine.shutdown();
+
+    // Recreate engine to load from snapshot
+    const persistenceReload = new SnapshotPersistence(snapshotPath);
+    engine = new SearchEngine({
+        tokenizer: new Tokenizer(stopwordsManager),
+        scorerFactory,
+        invertedIndex: new InvertedIndex(),
+        rankingPipeline: new RankingPipeline(),
+        stopwordsManager,
+        synonymEngine: new SynonymEngine(),
+        mappingsManager,
+        persistence: persistenceReload,
+        facetFields: ['status'],
+    });
+
+    const results = engine.search('persistent');
+    assert.strictEqual(results.hits.length, 1);
+    assert.deepStrictEqual(engine.documents.get('doc1'), doc);
+    assert.deepStrictEqual(results.facets, { status: { A: 1 } });
+
+    engine.shutdown();
+    await unlink(snapshotPath).catch(() => { });
+});


### PR DESCRIPTION
## Summary
- Ensure SearchEngine reload updates query engine and rebuilds facet index from persisted snapshot
- Add regression test verifying snapshot persistence retains documents and facets

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c5a7c98950832593916166faf36b93